### PR TITLE
Fixed a bug with RTree

### DIFF
--- a/src/com/newbrightidea/util/RTree.java
+++ b/src/com/newbrightidea/util/RTree.java
@@ -446,7 +446,7 @@ public class RTree<T>
           nMinUb = n;
         }
       }
-      float sep = (nMaxLb == nMinUb) ? 0.0f :
+      float sep = (nMaxLb == nMinUb) ? -1.0f :
                   Math.abs((dimMinUb - dimMaxLb) / (dimUb - dimLb));
       if (sep >= bestSep)
       {


### PR DESCRIPTION
Hi,
 Thanks for your RTree. I'm currently using it in one of my projects. I fixed a very rare bug that happens upon a split and causes two nodes to have the same child. The problem happens when the algorithm is looking for the best pair to split and it happens that the first and only pair found is actually the same node twice (nMaxLb == nMinUb). In this case the score is set to zero which happens to be equal to the best score, hence, this pair is actually chosen for split. I corrected it by setting the score to -1 so that a similar pair is never chosen for split.
Thank you
